### PR TITLE
Replaced Error throwing to specialized SignatureVerificationException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.adscore'
-version '1.0.4'
+version '1.0.5'
 
 sourceCompatibility = 1.8
  

--- a/src/main/java/com/adscore/signature/SignatureVerifierService.java
+++ b/src/main/java/com/adscore/signature/SignatureVerifierService.java
@@ -312,7 +312,7 @@ public class SignatureVerifierService {
           if (v.containsKey("v")) {
             data.put(fieldTypeDef.getName(), v.get("v"));
           } else {
-            throw new Error("premature end of signature 0x03");
+            throw new SignatureVerificationException("premature end of signature 0x03");
           }
           signature = SignatureVerifierUtils.substr(signature, 3);
           break;
@@ -321,14 +321,14 @@ public class SignatureVerifierService {
           if (v.containsKey("v")) {
             data.put(fieldTypeDef.getName(), v.get("v"));
           } else {
-            throw new Error("premature end of signature 0x04");
+            throw new SignatureVerificationException("premature end of signature 0x04");
           }
           signature = SignatureVerifierUtils.substr(signature, 5);
           break;
         case "string":
           l = Unpacker.unpack("Cx/nl", signature).getData();
           if (!l.containsKey("l")) {
-            throw new Error("premature end of signature 0x05");
+            throw new SignatureVerificationException("premature end of signature 0x05");
           }
           if ((SignatureVerifierUtils.characterToInt(l.get("l")) & 0x8000) > 0) {
             int newl = SignatureVerifierUtils.characterToInt(l.get("l")) & 0xFF;


### PR DESCRIPTION
Changes:

Changed `Error` throwing (https://github.com/Adscore/client-libs-java/issues/3) to more specialized `SignatureVerificationException` as catching `Error` in application code is bad practice. 

All JVM errors (like `OutOfMemoryError` or `NoClassDefFoundError`) are subclasses of Error and catching Error in application code that uses your library will also catch such JVM errors that can't be handled in a right way.
